### PR TITLE
fix a few compile errors in the examples

### DIFF
--- a/example/field_on_square/main.cpp
+++ b/example/field_on_square/main.cpp
@@ -36,5 +36,5 @@ int main(int argc, char** argv) {
   // finally enforcing that u_r correspond to a scalar field "u" at VERTices
   mesh.add_tag(Omega_h::VERT, "u", 1, u_r);
   // export the results to visualize in paraview
-  Omega_h::vtk::write_vtu("field_on_square.vtu", &mesh, mesh.dim(), "field");
+  Omega_h::vtk::write_vtu("field_on_square.vtu", &mesh, mesh.dim());
 }

--- a/example/laplacian/main.cpp
+++ b/example/laplacian/main.cpp
@@ -106,7 +106,7 @@ int main(int argc, char** argv) {
     for (std::size_t i = 0; i < 4; ++i) {
       // return type Omega_h::Read<Omega_h::I8> to store booleans
       const auto rs_are_brs =
-          mark_class_closure(&mesh, Omega_h::VERT, Omega_h::EDGE, i + 1);
+          mark_class_closure(&mesh, Omega_h::VERT, Omega_h::EDGE, Omega_h::LO(i + 1));
       // br+1 is a boundary index between 1 and the number of boundary vertices
       const auto br2r = collect_marked(rs_are_brs);
 


### PR DESCRIPTION
Building with Apple LLVM version 10.0.0 (clang-1000.10.44.4) on OSX with a minimal config, `cmake ../ -DOmega_h_EXAMPLES=ON`, there were compile errors in the `laplacian` and `field_on_square` examples.  This PR fixes the errors:
```
[ 80%] Building CXX object example/laplacian/CMakeFiles/osh_laplacian.dir/main.cpp.o
/Users/cwsmith/develop/omega_h/example/laplacian/main.cpp:109:69: error: implicit
      conversion loses integer precision: 'unsigned long' to 'Omega_h::LO'
      (aka 'int') [-Werror,-Wshorten-64-to-32]
          mark_class_closure(&mesh, Omega_h::VERT, Omega_h::EDGE, i + 1);
          ~~~~~~~~~~~~~~~~~~                                      ~~^~~
1 error generated.
```

```
[ 73%] Building CXX object example/field_on_square/CMakeFiles/osh_field_on_square.dir/main.cpp.o
/Users/cwsmith/develop/omega_h/example/field_on_square/main.cpp:39:69: error:
      implicit conversion turns string literal into bool: 'const char [6]' to
      'bool' [-Werror,-Wstring-conversion]
  Omega_h::vtk::write_vtu("field_on_square.vtu", &mesh, mesh.dim(), "field");
  ~~~~~~~                                                           ^~~~~~~
1 error generated.
```