### PR TITLE
non-blocking sends in Omega_h_comm.cpp

### DIFF
--- a/src/Omega_h_comm.cpp
+++ b/src/Omega_h_comm.cpp
@@ -2,7 +2,6 @@
 
 #include <algorithm>
 #include <string>
-#include <iostream>
 
 #include "Omega_h_array_ops.hpp"
 #include "Omega_h_int_scan.hpp"


### PR DESCRIPTION
I replaced blocking sends with non-blocking sends in Omega_h_comm.cpp and observed that the time spent in Comm::alltoallv dropped by almost half for a FLEXO calculation on Serrano with 128 cores (4 nodes).