### PR TITLE
Omega_h_kokkos.cpp header case: K->k

### DIFF
--- a/src/Omega_h_fence.cpp
+++ b/src/Omega_h_fence.cpp
@@ -2,7 +2,7 @@
 #include <Omega_h_fail.hpp>
 
 #ifdef OMEGA_H_USE_KOKKOS
-#include <Omega_h_Kokkos.hpp>
+#include <Omega_h_kokkos.hpp>
 #endif
 
 namespace Omega_h {


### PR DESCRIPTION
`Omega_h_fence.cpp` included `Omega_h_Kokkos.hpp`.  This does not exist and the other headers use `*_kokkos.hpp`:

```shell
$ grep -ri Omega_h_kokkos.hpp *
src/CMakeLists.txt:  Omega_h_kokkos.hpp
src/Omega_h_array.hpp:#include <Omega_h_kokkos.hpp>
src/Omega_h_fence.cpp:#include <Omega_h_kokkos.hpp>
src/Omega_h_for.hpp:#include <Omega_h_kokkos.hpp>
src/Omega_h_kokkos.hpp:#ifndef OMEGA_H_KOKKOS_HPP
src/Omega_h_kokkos.hpp:#define OMEGA_H_KOKKOS_HPP
src/Omega_h_profile.hpp:#include <Omega_h_kokkos.hpp>
src/Omega_h_reduce.hpp:#include <Omega_h_kokkos.hpp>
src/Omega_h_scan.hpp:#include <Omega_h_kokkos.hpp>
```