### PR TITLE
Fix for exodus 2D side indexing, prevent Werror propagation

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -192,7 +192,7 @@ if (Omega_h_USE_CUDA)
   endif()
 else()
   if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    target_compile_options(omega_h PUBLIC
+    target_compile_options(omega_h PRIVATE
         -W
         -Wall
         -Wextra
@@ -200,7 +200,7 @@ else()
         -Wimplicit-fallthrough
         )
   elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-    target_compile_options(omega_h PUBLIC
+    target_compile_options(omega_h PRIVATE
         -W
         -Wall
         -Wextra

--- a/src/Omega_h_exodus.cpp
+++ b/src/Omega_h_exodus.cpp
@@ -77,7 +77,7 @@ static OMEGA_H_INLINE int side_exo2osh(
         case 2:
           // seeing files from CUBIT with triangle sides in {3,4,5}...
           // no clue what thats about, just modulo and move on
-          return (side) % 3;
+          return (side-1) % 3;
         case 3:
           switch (side) {
             case 1:
@@ -573,9 +573,9 @@ void write(
   }
   auto nelem_blocks = int(region_set.size());
   auto nside_sets =
-      (classify_with | exodus::SIDE_SETS) ? int(surface_set.size()) : 0;
+      (classify_with & exodus::SIDE_SETS) ? int(surface_set.size()) : 0;
   auto nnode_sets =
-      (classify_with | exodus::NODE_SETS) ? int(surface_set.size()) : 0;
+      (classify_with & exodus::NODE_SETS) ? int(surface_set.size()) : 0;
   if (verbose) {
     std::cout << "init params for " << path << ":\n";
     std::cout << " Exodus ID " << file << '\n';


### PR DESCRIPTION
Changes target_compile_options to private for clang and gcc to not propagate Werror to projects using Omega_h, unsure whether options are expected to propagate for MSVC and Cuda build

Changes exodus 2D side selection as it was incorrectly picking the wrong side on triangles (causing issues in #320)

Fixes some classify_with flag checks in read_sliced

Closes #320 