### PR TITLE
mark classes having `final` destructor with the `final` specifier as well

### DIFF
--- a/src/Omega_h_expr.cpp
+++ b/src/Omega_h_expr.cpp
@@ -855,7 +855,7 @@ any ExprReader::at_reduce(int prod, std::vector<any>& rhs) {
 
 ExprOp::~ExprOp() {}
 
-struct ConstOp : public ExprOp {
+struct ConstOp final : public ExprOp {
   double value;
   OpPtr rhs;
   virtual ~ConstOp() override final = default;
@@ -864,7 +864,7 @@ struct ConstOp : public ExprOp {
 };
 any ConstOp::eval(ExprEnv&) { return value; }
 
-struct SemicolonOp : public ExprOp {
+struct SemicolonOp final : public ExprOp {
   OpPtr lhs;
   OpPtr rhs;
   virtual ~SemicolonOp() override final = default;
@@ -876,7 +876,7 @@ any SemicolonOp::eval(ExprEnv& env) {
   return rhs->eval(env);
 }
 
-struct AssignOp : public ExprOp {
+struct AssignOp final : public ExprOp {
   std::string name;
   OpPtr rhs;
   virtual ~AssignOp() override final = default;
@@ -889,7 +889,7 @@ any AssignOp::eval(ExprEnv& env) {
   return any();
 }
 
-struct VarOp : public ExprOp {
+struct VarOp final : public ExprOp {
   std::string name;
   virtual ~VarOp() override final = default;
   VarOp(std::string const& name_in) : name(name_in) {}
@@ -905,7 +905,7 @@ any VarOp::eval(ExprEnv& env) {
   return it->second;
 }
 
-struct NegOp : public ExprOp {
+struct NegOp final : public ExprOp {
   OpPtr rhs;
   virtual ~NegOp() override final = default;
   NegOp(OpPtr rhs_in) : rhs(rhs_in) {}
@@ -913,7 +913,7 @@ struct NegOp : public ExprOp {
 };
 any NegOp::eval(ExprEnv& env) { return neg(env.dim, rhs->eval(env)); }
 
-struct TernaryOp : public ExprOp {
+struct TernaryOp final : public ExprOp {
   OpPtr cond;
   OpPtr lhs;
   OpPtr rhs;
@@ -929,7 +929,7 @@ any TernaryOp::eval(ExprEnv& env) {
   return ternary(env.size, env.dim, cond->eval(env), lhs_val, rhs_val);
 }
 
-struct CallOp : public ExprOp {
+struct CallOp final : public ExprOp {
   std::string name;
   std::vector<OpPtr> rhs;
   ExprEnv::Args args;
@@ -971,7 +971,7 @@ any CallOp::eval(ExprEnv& env) {
 }
 
 #define OMEGA_H_BINARY_OP(ClassName, func_call)                                \
-  struct ClassName : public ExprOp {                                           \
+  struct ClassName final : public ExprOp {                                     \
     OpPtr lhs;                                                                 \
     OpPtr rhs;                                                                 \
     virtual ~ClassName() override final = default;                             \

--- a/src/Omega_h_expr.hpp
+++ b/src/Omega_h_expr.hpp
@@ -33,7 +33,7 @@ struct ExprOp {
 
 using OpPtr = std::shared_ptr<ExprOp>;
 
-class ExprOpsReader : public Reader {
+class ExprOpsReader final : public Reader {
  public:
   ExprOpsReader();
   virtual ~ExprOpsReader() override final = default;
@@ -44,7 +44,7 @@ class ExprOpsReader : public Reader {
   any at_reduce(int token, std::vector<any>& rhs) override final;
 };
 
-class ExprReader : public Reader {
+class ExprReader final : public Reader {
  public:
   using Args = ExprEnv::Args;
   using Function = ExprEnv::Function;


### PR DESCRIPTION
It fixes build issues with clang 11:
```
     123    In file included from /Users/tristan/src/github.com/BlueBrain/omega_h/src/Omega_h_expr.cpp:4:
  >> 124    /Users/tristan/src/github.com/BlueBrain/omega_h/src/Omega_h_expr.hpp:52:34: error: class with destruct
            or marked 'final' cannot be inherited from [-Werror,-Wfinal-dtor-non-final-class]
     125      virtual ~ExprReader() override final;
     126                                     ^
     127    /Users/tristan/src/github.com/BlueBrain/omega_h/src/Omega_h_expr.hpp:47:7: note: mark 'Omega_h::ExprRe
            ader' as 'final' to silence this warning
     128    class ExprReader : public Reader {
```